### PR TITLE
Feature/facsimile view zoom

### DIFF
--- a/src/components/facsimiles/facsimiles.html
+++ b/src/components/facsimiles/facsimiles.html
@@ -19,17 +19,28 @@
 </ion-item>
 
 <div>
-  <img *ngIf="!facsimilePagesInfinite" [src]="images ? images[activeImage] : ''" style="width: 100%;"
-    [ngStyle]="{'transform':'scale('+zoom+') rotate('+angle+'deg)'}" (wheel)="onMouseWheel($event)" (pan)="handleSwipeEvent($event)" (mouseup)="setLatestPos($event)">
+  <img *ngIf="!facsimilePagesInfinite"
+    [src]="images ? images[activeImage] : ''"
+    style="width: 100%;"
+    [ngStyle]="{'transform':'scale('+zoom+') rotate('+angle+'deg) translate3d(' + prevX + 'px, ' + prevY + 'px, 0px)'}"
+    (wheel)="onMouseWheel($event)"
+    (pan)="handleSwipeEvent($event)"
+    (mouseup)="onMouseUp($event)"
+    (touchend)="onTouchEnd($event)"
+  >
 </div>
-
 
 <div>
-  <img *ngIf="facsimilePagesInfinite && facsNumber" [src]="facsUrl + facsNumbe" style="width: 100%;"
-    [ngStyle]="{'transform':'scale('+zoom+') rotate('+angle+'deg)'}" (wheel)="onMouseWheel($event)" (pan)="handleSwipeEvent($event)" (mouseup)="setLatestPos($event)">
+  <img *ngIf="facsimilePagesInfinite && facsNumber"
+    [src]="facsUrl + facsNumbe"
+    style="width: 100%;"
+    [ngStyle]="{'transform':'scale('+zoom+') rotate('+angle+'deg) translate3d(' + prevX + 'px, ' + prevY + 'px, 0px)'}"
+    (wheel)="onMouseWheel($event)"
+    (pan)="handleSwipeEvent($event)"
+    (mouseup)="onMouseUp($event)"
+    (touchend)="onTouchEnd($event)"
+  >
 </div>
-
-
 
 <ion-fab middle left class="leftFacsimileArrow">
   <button ion-fab color="primary" mini (click)="previous()">
@@ -60,6 +71,6 @@
 <div class="tei" [innerHTML]="text" [class.show_comments]="readPopoverService.show.comments"
   [class.show_personInfo]="readPopoverService.show.personInfo"
   [class.show_abbreviations]="readPopoverService.show.abbreviations"
-  [class.show_pageNumbering]="readPopoverService.show.pageNumbering" 
+  [class.show_pageNumbering]="readPopoverService.show.pageNumbering"
   [ngClass]="(readPopoverService.fontsize==0)?'smallFont':(readPopoverService.fontsize==1)?'mediumFont':'largeFont'">
 </div>

--- a/src/components/facsimiles/facsimiles.scss
+++ b/src/components/facsimiles/facsimiles.scss
@@ -97,5 +97,7 @@ facsimiles {
 
     img{
         cursor: move;
+        // https://github.com/hammerjs/hammer.js/issues/1050#issuecomment-267595556
+        touch-action: none;
     }
 }

--- a/src/components/facsimiles/facsimiles.scss
+++ b/src/components/facsimiles/facsimiles.scss
@@ -1,6 +1,7 @@
 facsimiles {
     .leftFacsimileArrow{
         left: 0;
+        right: auto !important;
     }
     .page_number_input input{
 

--- a/src/components/facsimiles/facsimiles.ts
+++ b/src/components/facsimiles/facsimiles.ts
@@ -9,6 +9,7 @@ import { ConfigService } from '@ngx-config/core';
 import { TranslateService } from '@ngx-translate/core';
 import { SongService } from '../../app/services/song/song.service';
 import { IfObservable } from 'rxjs/observable/IfObservable';
+
 /**
  * Generated class for the FacsimilesComponent component.
  *
@@ -41,8 +42,10 @@ export class FacsimilesComponent {
   manualPageNumber: number;
   zoom = 1.0;
   angle = 0;
-  latestDeltaX = null;
-  latestDeltaY = null;
+  latestDeltaX = 0
+  latestDeltaY = 0
+  prevX = 0
+  prevY = 0
 
   facsUrl = '';
   facsimilePagesInfinite = false;
@@ -342,14 +345,14 @@ export class FacsimilesComponent {
 
   handleSwipeEvent(event) {
     const img = event.target;
-    let x = event.deltaX;
-    let y = event.deltaY;
-    if ( this.latestDeltaX !== null ) {
-      x = this.latestDeltaX;
-      y = this.latestDeltaY;
-      this.latestDeltaX = null;
-      this.latestDeltaY = null;
-    }
+    // Store latest zoom adjusted delta.
+    this.latestDeltaX = event.deltaX / this.zoom
+    this.latestDeltaY = event.deltaY / this.zoom
+
+    // Get current position from last position and delta.
+    let x = this.prevX + this.latestDeltaX
+    let y = this.prevY + this.latestDeltaY
+
     if ( this.angle === 90 ) {
       const tmp = x;
       x = y;
@@ -364,28 +367,34 @@ export class FacsimilesComponent {
       y = tmp;
       x = x * -1;
     }
+
     if (img !== null) {
       img.style.transform = 'rotate(' + this.angle + 'deg) scale(' + this.zoom + ') translate3d(' + x + 'px, ' + y + 'px, 0px)';
     }
   }
 
-  setLatestPos(e) {
-    this.latestDeltaX = e.clientX - e.offsetX;
-    this.latestDeltaY = e.clientY - e.offsetY;
+  onMouseUp(e) {
+    // Update the previous position on desktop by adding the latest delta.
+    this.prevX += this.latestDeltaX
+    this.prevY += this.latestDeltaY
+  }
+
+  onTouchEnd(e) {
+    // Update the previous position on mobile by adding the latest delta.
+    this.prevX += this.latestDeltaX
+    this.prevY += this.latestDeltaY
   }
 
   onMouseWheel(e) {
     const img = e.target;
-    this.latestDeltaY = e.clientY - e.offsetY;
-    this.latestDeltaX = e.clientX - e.offsetX;
     if ( e.deltaY > 0 ) {
       this.zoomIn();
-      img.style.transform = 'rotate(' + this.angle + 'deg) scale(' + this.zoom + ') translate3d(' + this.latestDeltaX + 'px, ' +
-       this.latestDeltaY + 'px, 0px)';
+      img.style.transform = 'rotate(' + this.angle + 'deg) scale(' + this.zoom + ') translate3d(' + this.prevX + 'px, ' +
+       this.prevY + 'px, 0px)';
     } else {
       this.zoomOut();
-      img.style.transform = 'rotate(' + this.angle + 'deg) scale(' + this.zoom + ') translate3d(' + this.latestDeltaX + 'px, ' +
-       this.latestDeltaY + 'px, 0px)';
+      img.style.transform = 'rotate(' + this.angle + 'deg) scale(' + this.zoom + ') translate3d(' + this.prevX + 'px, ' +
+       this.prevY + 'px, 0px)';
     }
   }
 

--- a/src/pages/read/read.html
+++ b/src/pages/read/read.html
@@ -21,6 +21,16 @@
   </ion-toolbar>
 </ion-header>
 
+<!-- Main content without scroll. The mobile facsimile requires a no scrolling content to function correctly.
+This is a dirty hack only because of the pending refactor. -->
+<div *ngIf="userSettingsService.isMobile() && show === 'facsimiles'; else mainContent" class="no-scroll">
+  <ion-content padding (swipe)="swipePrevNext($event)" color="secondary">
+    <facsimiles [itemId]="establishedText.link" [matches]="matches" [facsID]="facs_id" [facsNr]="facs_nr" [songID]="song_id"></facsimiles>
+  </ion-content>
+</div>
+
+<!-- Main content with scroll -->
+<ng-template #mainContent>
 <ion-content padding (swipe)="swipePrevNext($event)" color="secondary">
   <div *ngIf="userSettingsService.isDesktop() && !userSettingsService.isTablet()" class="column-container">
 
@@ -64,7 +74,8 @@
                 </button>
               </ion-fab-list>
             </ion-fab>
-            <ion-scroll scrollY="true" style="height:100vh;" class="card" #scrollBar>
+            <!-- Don't scroll in facsimile view -->
+            <ion-scroll [scrollY]="!view.facsimiles.show" style="height:100vh;" class="card" #scrollBar>
               <div *ngIf="view.established.show">
                 <read-text [link]="establishedText.link" [matches]="matches" [external]="external"></read-text>
               </div>
@@ -213,3 +224,4 @@
   </ng-container>
 
 </ion-content>
+</ng-template>

--- a/src/pages/read/read.scss
+++ b/src/pages/read/read.scss
@@ -15,7 +15,7 @@ page-read {
 		font-size: 1rem !important;
 		min-width: max-content;
 	}
-	
+
 	.segment-activated{
 		background-color: color($colors, primary) !important;
 		color: color($colors, white) !important;
@@ -96,7 +96,7 @@ page-read {
     .tooltip {
         display: none;
 	}
-	
+
 	.tooltiptrigger{
 		cursor: pointer;
 	}
@@ -193,7 +193,7 @@ page-read {
 		right: -10px !important;
 		top: -15px;
 	}
-	
+
 	.occurrenceButton{
 		float: left;
 		z-index: 999;
@@ -223,7 +223,7 @@ page-read {
 		font-size: 1.0rem;
 		color: #78756f;
 	}
-	
+
 	.collections{
 		font-size: 1.0rem;
 		color: #78756f;
@@ -236,5 +236,14 @@ page-read {
 	.swiper-slide .swiper-slide-active{
 	   width: 240px;//your width here
 	   border: 1px solid black;
-   }
- }
+  }
+}
+
+.no-scroll {
+  padding-top: 40px;
+  height: 100%;
+
+  .scroll-content {
+    overflow: hidden;
+  }
+}


### PR DESCRIPTION
**Fix facsimile view zooming and panning**

Previously:
* Panning always reseted when new panning started.
* Panning did not respect the zoom level.
* Zoom always reseted to center of the facsimile.
* Page scroll broke facsimile view when zoomed in.

Note: I couldn't make the mobile pinch zoom work in facsimile view. Everything else works now on mobile and desktop but in order to zoom on mobile you need to tap the zoom buttons or go to the facsimile zoom view to pinch zoom there. This is a trade of in time usage and making the perfect.

Todo: Next I'll fix the facsimile zoom view on desktop (on mobile it seems to work as intended).

**Remove unwanted element in the middle of the facsimile**
