### PR TITLE
Give Beta search icon separate ID

### DIFF
--- a/src/components/top-menu/top-menu.html
+++ b/src/components/top-menu/top-menu.html
@@ -25,7 +25,7 @@
                   <ion-icon name="search"></ion-icon>
                   <span class="side-title">{{'TopMenu.SimpleSearch' | translate }}</span>
                 </button>
-                <button *ngIf="showTopElasticButton" ion-button class="top-menu-button" (click)="elasticSearch()" id="searchIcon">
+                <button *ngIf="showTopElasticButton" ion-button class="top-menu-button" (click)="elasticSearch()" id="searchIconBeta">
                   <ion-icon name="search"></ion-icon>
                   <span class="side-title">{{'TopMenu.AdvancedSearch' | translate }}
                     <strong>(BETA)</strong></span>
@@ -82,7 +82,7 @@
                 <button ion-button class="top-menu-button" (click)="elasticSearch()" id="searchIcon">
                   <ion-icon name="search"></ion-icon>
                 </button>
-                <button ion-button class="top-menu-button" (click)="elasticSearch()" id="searchIcon">
+                <button ion-button class="top-menu-button" (click)="elasticSearch()" id="searchIconBeta">
                   <ion-icon name="search"></ion-icon>
                   <span class="side-title">{{'TopMenu.AdvancedSearch' | translate }}
                     <strong>(BETA)</strong></span>


### PR DESCRIPTION
Enables the possibility to apply CSS to only one button, and not both.
E.g. hiding  the non-beta search button